### PR TITLE
Add missing argument to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ Gets all the pages of virtualnetworks
 - Id (optional) - Id of the Virtual Server to open the console of (Either Id or Name is required)
 - Name (optional) - Name of the Virtual Server to open the console of (Either Id or Name is required)
 
+### Get-VmSnapshots
+- Id (optional) - Id of the Virtual Server for which you would like to list snapshots
+- Name (Optional) - Name of the Virtual Server for which you would like to list snapshots
+
 ### New-VmSnapshot
 - Id (optional) - Id of the Virtual Server to create a snapshot of (Either Id or Name is required)
 - Name (optional) - Name of the Virtual Server to create a snapshot of (Either Id or Name is required)


### PR DESCRIPTION
I was in the progress of making an argument that lists VmSnapshots, when I found it was already there. Edited the README instead.